### PR TITLE
[Tests] Remove useless Rospack

### DIFF
--- a/tests/python/test_simple_distribute.py
+++ b/tests/python/test_simple_distribute.py
@@ -6,7 +6,6 @@ import pinocchio as pin
 from dynamic_graph.sot_talos_balance.create_entities_utils import (create_parameter_server,
                                                                    create_simple_distribute_wrench)
 from numpy.testing import assert_almost_equal as assertApprox
-from rospkg import RosPack
 
 # --- General ---
 print("--- General ---")


### PR DESCRIPTION
Actually, I believe that we should just remove rospack everywhere in all our codebase, but that's a first step. This one is useless, and make CI fail in 20.04, as rospack is not available on that image (it could be, but that's not relevant).